### PR TITLE
Better error message for wrong encoding

### DIFF
--- a/lib/miscreant/aes/siv.rb
+++ b/lib/miscreant/aes/siv.rb
@@ -68,7 +68,7 @@ module Miscreant
       # @raise [Miscreant::IntegrityError] ciphertext and/or associated data are corrupt or tampered with
       # @return [String] decrypted plaintext
       def open(ciphertext, associated_data = [])
-        raise TypeError, "expected String, got #{ciphertext.class}" unless ciphertext.is_a?(String)
+        Internals::Util.validate_bytestring("ciphertext", ciphertext)
 
         v = ciphertext[0, Internals::Block::SIZE]
         plaintext = @ctr.encrypt(_zero_iv_bits(v), ciphertext[Internals::Block::SIZE..-1])

--- a/spec/miscreant/aead_spec.rb
+++ b/spec/miscreant/aead_spec.rb
@@ -53,6 +53,15 @@ RSpec.describe Miscreant::AEAD do
           end.to raise_error(Miscreant::IntegrityError)
         end
       end
+
+      it "should raise ArgumentError if wrong encoding" do
+        ex = test_vectors.first
+        aead = described_class.new(ex.alg, ex.key)
+        ciphertext = ex.ciphertext.dup.force_encoding(Encoding::UTF_8)
+        expect do
+          aead.open(ciphertext, nonce: example_nonce, ad: example_ad)
+        end.to raise_error(ArgumentError, "ciphertext must be Encoding::BINARY")
+      end
     end
   end
 end


### PR DESCRIPTION
Hi, thanks for this neat library! This improves the error message when the ciphertext has the wrong encoding. The current message is `IV must be Encoding::BINARY`, which makes it seem like the nonce instead of the ciphertext.

```text
	3: from /Users/andrew/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/miscreant-0.3.0/lib/miscreant/aead.rb:90:in `open'
	2: from /Users/andrew/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/miscreant-0.3.0/lib/miscreant/aes/siv.rb:71:in `open'
	1: from /Users/andrew/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/miscreant-0.3.0/lib/miscreant/internals/aes/ctr.rb:31:in `encrypt'
/Users/user/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/miscreant-0.3.0/lib/miscreant/internals/util.rb:64:in `validate_bytestring': IV must be Encoding::BINARY (ArgumentError)
```